### PR TITLE
mamba: Don't fetch expected dependencies

### DIFF
--- a/mamba/SOURCES/0001-dont-fetch-from-git.patch
+++ b/mamba/SOURCES/0001-dont-fetch-from-git.patch
@@ -1,0 +1,24 @@
+--- expected-1.0.0/CMakeLists.txt.orig  2022-12-22 11:12:09.566688832
+-0600
++++ expected-1.0.0/CMakeLists.txt       2022-12-22 11:16:32.575420953
+-0600
+@@ -4,17 +4,8 @@
+
+ option(EXPECTED_ENABLE_TESTS "Enable tests." ON)
+
+ -include(FetchContent)
+ -FetchContent_Declare(
+ -  tl_cmake
+ -  GIT_REPOSITORY https://github.com/TartanLlama/tl-cmake.git
+ -)
+ -FetchContent_GetProperties(tl_cmake)
+ -if(NOT tl_cmake_POPULATED)
+ -  FetchContent_Populate(tl_cmake)
+ -  set(CMAKE_MODULE_PATH ${tl_cmake_SOURCE_DIR} ${CMAKE_MODULE_PATH})
+ -endif()
+ -include(add-tl)
+ +include(add-tl.cmake)
+ +set(CMAKE_MODULE_PATH ${tl_cmake_SOURCE_DIR} ${CMAKE_MODULE_PATH})
+
+  tl_add_library(expected SOURCES
+                  include/tl/expected.hpp)

--- a/mamba/SPECS/mamba.spec
+++ b/mamba/SPECS/mamba.spec
@@ -28,29 +28,31 @@
 %define fmt_version 9.1.0
 %define conda_version 22.11.1
 
-# Mamba maintainers label the source code with date, not version :( 
+# Mamba maintainers label the source code with date, not version :(
 %define date 2022.11.01
 
 Name:       %{pname}-%{compiler_family}%{PROJ_DELIM}
 Version:    1.0.0
-Release:    2%{?dist}
+Release:    3%{?dist}
 Summary:    Mamba Package Manager
 License:    BSD-3-Clause
 URL:        https://github.com/mamba-org/mamba
-Source0:    https://github.com/mamba-org/mamba/archive/refs/tags/%{date}.tar.gz
+Source0:    https://github.com/mamba-org/mamba/archive/refs/tags/%{date}.tar.gz#/mamba-%{date}.tar.gz
 Source1:    https://github.com/nlohmann/json/releases/download/v%{nlohmann_json_version}/json.tar.xz
-Source2:    https://github.com/pybind/pybind11/archive/refs/tags/v%{pybind11_version}.tar.gz
-Source3:    https://github.com/DaanDeMeyer/reproc/archive/refs/tags/v%{reproc_version}.tar.gz
-Source4:    https://github.com/TartanLlama/expected/archive/refs/tags/v%{expected_version}.tar.gz
-Source5:    https://github.com/ikalnytskyi/termcolor/archive/refs/tags/v%{termcolor_version}.tar.gz
+Source2:    https://github.com/pybind/pybind11/archive/refs/tags/v%{pybind11_version}.tar.gz#/pybind11-%{pybind11_version}.tar.gz
+Source3:    https://github.com/DaanDeMeyer/reproc/archive/refs/tags/v%{reproc_version}.tar.gz#/reproc-%{reproc_version}.tar.gz
+Source4:    https://github.com/TartanLlama/expected/archive/refs/tags/v%{expected_version}.tar.gz#/expected-%{expected_version}.tar.gz
+Source5:    https://github.com/ikalnytskyi/termcolor/archive/refs/tags/v%{termcolor_version}.tar.gz#/termcolor-%{termcolor_version}.tar.gz
 Source6:    https://github.com/curl/curl/releases/download/curl-7_86_0/curl-%{curl_version}.tar.bz2
-Source7:    https://github.com/openSUSE/libsolv/archive/refs/tags/%{libsolv_version}.tar.gz
-Source8:    https://github.com/gabime/spdlog/archive/refs/tags/v%{spdlog_version}.tar.gz
-Source9:    https://github.com/fmtlib/fmt/archive/refs/tags/%{fmt_version}.tar.gz
-Source10:   OHPC_setup_compiler
+Source7:    https://github.com/openSUSE/libsolv/archive/refs/tags/%{libsolv_version}.tar.gz#/libsolve-%{libsolv_version}.tar.gz
+Source8:    https://github.com/gabime/spdlog/archive/refs/tags/v%{spdlog_version}.tar.gz#/spdlog-%{spdlog_version}.tar.gz
+Source9:    https://github.com/fmtlib/fmt/archive/refs/tags/%{fmt_version}.tar.gz#/fmt-%{fmt_version}.tar.gz
+Source10:   https://raw.githubusercontent.com/TartanLlama/tl-cmake/master/add-tl.cmake
+Source11:   OHPC_setup_compiler
 
 
 Patch0:     lib_path.patch
+Patch1:     0001-dont-fetch-from-git.patch
 
 %define install_path %{OHPC_APPS}/%{compiler_family}/%{pname}%{OHPC_CUSTOM_PKG_DELIM}/%{version}
 
@@ -80,6 +82,8 @@ Mamba is a reimplementation of the conda package manager in C++.
 %prep
 %setup -q -a 1 -a 2 -a 3 -a 4 -a 5 -a 6 -a 7 -a 8 -a 9 -n %{pname}-%{date}
 %patch0 -p0
+%patch1 -p0
+cp %SOURCE10 expected-%{expected_version}
 
 %build
 %ohpc_setup_compiler
@@ -139,7 +143,7 @@ cd ../libsolv-%{libsolv_version}
 
 cmake -B build \
   -DCMAKE_INSTALL_PREFIX=%{install_path}/libsolv \
-  -DENABLE_CONDA=ON 
+  -DENABLE_CONDA=ON
 cmake --build build
 make DESTDIR=%{buildroot} install -C build/
 
@@ -149,7 +153,7 @@ cmake -B build \
   -DCMAKE_INSTALL_PREFIX=%{install_path}/fmt \
   -DFMT_TEST=OFF \
   -DFMT_DOC=OFF \
-  -DBUILD_SHARED_LIBS=ON 
+  -DBUILD_SHARED_LIBS=ON
 cmake --build build
 make DESTDIR=%{buildroot} install -C build/
 
@@ -186,7 +190,7 @@ mv %{buildroot}$PWD/libmambapy/libmambapy/bindings.cpython-38-x86_64-linux-gnu.s
 export LD_LIBRARY_PATH=%{buildroot}%{install_path}/libmamba/lib64:%{buildroot}%{install_path}/libsolv/lib64:%{buildroot}%{install_path}/curl/lib64:%{buildroot}%{install_path}/spdlog/lib64:%{buildroot}%{install_path}/fmt/lib64:%{buildroot}%{install_path}/reproc/lib64:$LD_LIBRARY_PATH
 
 pip3.8 install libmambapy/ --no-deps --prefix="%{buildroot}%{install_path}/libmambapy"
-pip3.8 install mamba/ --no-deps --prefix="%{buildroot}%{install_path}/mamba" 
+pip3.8 install mamba/ --no-deps --prefix="%{buildroot}%{install_path}/mamba"
 
 # Remove buildroot from cmake targets
 sed -i 's|%{buildroot}||g' %{buildroot}%{install_path}/libmamba/lib64/cmake/libmamba/libmambaTargets.cmake
@@ -202,7 +206,7 @@ sed -i 's|$(\\dirname "${CONDA_EXE}")/mamba|%{install_path}/mamba/bin/mamba|' %{
 help([[
   This module loads the %{pname} package for the Mamba package and environment
   manager.
-  
+
   Version %{version}
 ]])
 
@@ -278,9 +282,10 @@ EOF
 %license LICENSE
 
 %changelog
+* Thu Dec 22 2022 Sol Jerome <solj@utdallas.edu> 1.0.0-3.ohpc
+- Fix expected build to work without network
 * Wed Dec 21 2022 Georgia Stuart <georgia.stuart@gmail.com> 1.0.0-2.ohpc
 - Refactor out python dependencies to rely on python38-ohpc
 - Fix path for Mamba executable
 * Thu Dec 15 2022 Georgia Stuart <georgia.stuart@gmail.com> - 1.0.0
 - Initial Mamba ohpc RPM
-


### PR DESCRIPTION
This disables the fetching of expected dependencies via git. The dependency consists of a single file so we just include the file instead.

Signed-off-by: Sol Jerome <solj@utdallas.edu>